### PR TITLE
Force ELF on macOS

### DIFF
--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -688,9 +688,13 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::thumb:
   case Triple::x86:
   case Triple::x86_64:
-    if (T.isOSDarwin())
-      return Triple::MachO;
-    else if (T.isOSWindows())
+    // Workaround for macOS
+    // LLVM fails to correctly set up trampolines with Mach-O,
+    // so we just force LLVM to use ELF instead.
+    //if (T.isOSDarwin())
+    //  return Triple::MachO;
+    //else
+    if (T.isOSWindows())
       return Triple::COFF;
     return Triple::ELF;
 


### PR DESCRIPTION
Fixes PPU LLVM in RPCS3.

A few days ago, I realized only system calls were actually causing the PPU crashes. After digging deep into LLVM's code with a lot of help from GalCiv, we came to the conclusion that LLVM wasn't setting up trampolines for imported symbols correctly. Nekotekina suggested forcing LLVM to generate ELF objects instead of Mach-O, and it actually worked!