### PR TITLE
Fix GHC tail calls for arm64

### DIFF
--- a/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5526,7 +5526,7 @@ SDValue AArch64TargetLowering::LowerCallResult(
 /// Return true if the calling convention is one that we can guarantee TCO for.
 static bool canGuaranteeTCO(CallingConv::ID CC, bool GuaranteeTailCalls) {
   return (CC == CallingConv::Fast && GuaranteeTailCalls) ||
-         CC == CallingConv::Tail || CC == CallingConv::SwiftTail;
+         CC == CallingConv::Tail || CC == CallingConv::SwiftTail || CC == CallingConv::GHC;
 }
 
 /// Return true if we might ever do TCO for calls with this calling convention.
@@ -5539,6 +5539,7 @@ static bool mayTailCallThisCC(CallingConv::ID CC) {
   case CallingConv::SwiftTail:
   case CallingConv::Tail:
   case CallingConv::Fast:
+  case CallingConv::GHC:
     return true;
   default:
     return false;


### PR DESCRIPTION
~~ELF breaks on arm64 macOS due to some relocation issue and errors out in LLVM backend. Using MachO fails to generate trampolines. COFF seems to work if we remove the checks that limit it to Windows targets.~~

GHC tail call is also broken on arm64. No idea why this isn't an issue in GHC upstream but both `mayTailCallThisCC` and `canGuaranteeTCO` were returning false for GHC because GHC wasn't set as a case. This led to tail call returns silently failing because LLVM in arm64 is set to ignore prologue/epilogue for GHC but because LLVM thinks tail calls are disabled for GHC it uses branch and link to call functions leading to infinite loop on function return as `ret` tries to jump to `lr` but `lr` is the address of `ret`. I fixed this to match the x86 backend which does mark GHC as guaranteed TCO.