### PR TITLE
Fix register clobbering on aarch64 GHC when mixing tail/non-tail calls

### DIFF
--- a/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/lib/Target/AArch64/AArch64CallingConvention.td
@@ -508,6 +508,9 @@ def CSR_Darwin_AArch64_CXX_TLS_ViaCopy
 def CSR_Darwin_AArch64_RT_MostRegs
     : CalleeSavedRegs<(add CSR_Darwin_AArch64_AAPCS, (sequence "X%u", 9, 15))>;
 
+def CSR_AArch64_NoRegs_LR
+    : CalleeSavedRegs<(add CSR_AArch64_NoRegs, LR)>;
+
 // Variants of the standard calling conventions for shadow call stack.
 // These all preserve x18 in addition to any other registers.
 def CSR_AArch64_NoRegs_SCS

--- a/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -1165,11 +1165,6 @@ void AArch64FrameLowering::emitPrologue(MachineFunction &MF,
         .setMIFlag(MachineInstr::FrameSetup);
   }
 
-  // All calls are tail calls in GHC calling conv, and functions have no
-  // prologue/epilogue.
-  if (MF.getFunction().getCallingConv() == CallingConv::GHC)
-    return;
-
   // Set tagged base pointer to the requested stack slot.
   // Ideally it should match SP value after prologue.
   Optional<int> TBPI = AFI->getTaggedBasePointerIndex();
@@ -1676,11 +1671,6 @@ void AArch64FrameLowering::emitEpilogue(MachineFunction &MF,
   int64_t NumBytes = IsFunclet ? getWinEHFuncletFrameSize(MF)
                                : MFI.getStackSize();
   AArch64FunctionInfo *AFI = MF.getInfo<AArch64FunctionInfo>();
-
-  // All calls are tail calls in GHC calling conv, and functions have no
-  // prologue/epilogue.
-  if (MF.getFunction().getCallingConv() == CallingConv::GHC)
-    return;
 
   // How much of the stack used by incoming arguments this function is expected
   // to restore in this particular epilogue.
@@ -2733,10 +2723,6 @@ bool AArch64FrameLowering::restoreCalleeSavedRegisters(
 void AArch64FrameLowering::determineCalleeSaves(MachineFunction &MF,
                                                 BitVector &SavedRegs,
                                                 RegScavenger *RS) const {
-  // All calls are tail calls in GHC calling conv, and functions have no
-  // prologue/epilogue.
-  if (MF.getFunction().getCallingConv() == CallingConv::GHC)
-    return;
 
   TargetFrameLowering::determineCalleeSaves(MF, SavedRegs, RS);
   const AArch64RegisterInfo *RegInfo = static_cast<const AArch64RegisterInfo *>(

--- a/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5526,7 +5526,7 @@ SDValue AArch64TargetLowering::LowerCallResult(
 /// Return true if the calling convention is one that we can guarantee TCO for.
 static bool canGuaranteeTCO(CallingConv::ID CC, bool GuaranteeTailCalls) {
   return (CC == CallingConv::Fast && GuaranteeTailCalls) ||
-         CC == CallingConv::Tail || CC == CallingConv::SwiftTail || CC == CallingConv::GHC;
+         CC == CallingConv::Tail || CC == CallingConv::SwiftTail;
 }
 
 /// Return true if we might ever do TCO for calls with this calling convention.

--- a/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
+++ b/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
@@ -615,6 +615,7 @@ static bool mayTailCallThisCC(CallingConv::ID CC) {
   case CallingConv::SwiftTail:
   case CallingConv::Tail:
   case CallingConv::Fast:
+  case CallingConv::GHC:
     return true;
   default:
     return false;


### PR DESCRIPTION
When we make L2 syscalls LLVM compiles Calls to branch-and-link instruction on arm64, whereas it uses call instruction on x86. The latter pushes the return address to the stack regardless of calling convention, so GHC doesn't need to save any registers even when calling between C++/JIT code.

But GHC assumes every call is a tail call+GHC CC and therefore doesn't need to save any registers, even though we call to non-GHC code e.g. L2 syscall function, using normal BLR+ret in arm64. So when we call to rpcs3 C++ code from JITed code, under GHC we don't save the previous LR in the JITed code before replacing it with the BLR call, which causes returns from syscalls to potentially return to wrong code.

This fixes that bug by re-enabling prologue/epilogue generation logic for GHC. Tail calls within JITed code are still proper tail calls but if we mark rpcs3 handling of JIT -> C++ calls as non-tail, then prologue/epilogue is properly emitted for those calls from JIT code.

Combined with virtual memory fixes and aarch64 specific intrinsics this gets the `ppu_thread.elf` test to pass on macOS arm64.